### PR TITLE
BugSplat post fixes

### DIFF
--- a/projects/bugsplat-ng/src/lib/bugsplat-error-handler.ts
+++ b/projects/bugsplat-ng/src/lib/bugsplat-error-handler.ts
@@ -30,9 +30,6 @@ export class BugSplatErrorHandler implements ErrorHandler {
     } else {
       this.bugsplat.logger.info('Exception caught by BugSplat!');
       this.bugsplat.post(error);
-      if (this.bugsplat.rethrowErrors) {
-        throw error;
-      }
     }
   }
 }

--- a/projects/bugsplat-ng/src/lib/bugsplat.ts
+++ b/projects/bugsplat-ng/src/lib/bugsplat.ts
@@ -44,18 +44,23 @@ export class BugSplat {
       body.append(file.name, file, file.name);
     });
     this.logPostInfo(url, callstack);
-    this.http.post(url, body).subscribe(data => {
-      this.logger.info("BugSplat POST Success: " + JSON.stringify(data));
-      const responseData = BugSplatResponseData.createFromSuccessResponseObject(data);
-      const event = new BugSplatPostEvent(BugSplatPostEventType.Success, responseData);
-      this.bugSplatPostEventSubject.next(event);
-    }, err => {
-      this.logger.error("BugSplat POST Error: " + JSON.stringify(err));
-      const httpErrorResponse = <HttpErrorResponse>err;
-      const responseData = BugSplatResponseData.createFromHttpErrorResponse(httpErrorResponse);
-      const event = new BugSplatPostEvent(BugSplatPostEventType.Error, responseData);
-      this.bugSplatPostEventSubject.next(event);
+    this.http.post(url, body)
+      .toPromise()
+      .then(data => {
+        this.logger.info("BugSplat POST Success: " + JSON.stringify(data));
+        const responseData = BugSplatResponseData.createFromSuccessResponseObject(data);
+        const event = new BugSplatPostEvent(BugSplatPostEventType.Success, responseData);
+        this.bugSplatPostEventSubject.next(event);
+      }, err => {
+        this.logger.error("BugSplat POST Error: " + JSON.stringify(err));
+        const httpErrorResponse = <HttpErrorResponse>err;
+        const responseData = BugSplatResponseData.createFromHttpErrorResponse(httpErrorResponse);
+        const event = new BugSplatPostEvent(BugSplatPostEventType.Error, responseData);
+        this.bugSplatPostEventSubject.next(event);
     });
+    if (this.rethrowErrors) {
+      throw error;
+    }
   }
 
   addAdditionalFile(file: File): void {

--- a/projects/bugsplat-ng/src/test/bugsplat.spec.ts
+++ b/projects/bugsplat-ng/src/test/bugsplat.spec.ts
@@ -34,6 +34,7 @@ describe('BugSplat', () => {
             return of(mockSuccessResponse);
         };
         const bugsplat = new BugSplat(config, http, new BugSplatLogger());
+        bugsplat.rethrowErrors = false;
         bugsplat.getObservable().subscribe(event => {
             expect(event.type).toEqual(BugSplatPostEventType.Success);
             expect(event.responseData.message).toEqual(expectedResponse.message);
@@ -63,6 +64,7 @@ describe('BugSplat', () => {
             return throwError(mockFailureResponse);
         };
         const bugsplat = new BugSplat(config, http, new BugSplatLogger());
+        bugsplat.rethrowErrors = false;
         bugsplat.getObservable().subscribe(event => {
             expect(event.type).toEqual(expectedResponse.type);
             expect(event.responseData.success).toEqual(expectedResponse.success);
@@ -79,7 +81,7 @@ describe('BugSplat', () => {
         const spy = spyOn(logger, "warn");
         const sizeLimitBytes = 2 * 1024 * 1024;
         const fileName = "mario.png";
-        const blob = new Blob([new Array(sizeLimitBytes + 1)], { type: 'image/png' });
+        const blob = new Blob([(new Array(sizeLimitBytes + 1)).toString()], { type: 'image/png' });
         const file = new File([blob], fileName);
         const bugsplat = new BugSplat(config, http, logger);
         const expectedMessage = "BugSplat Error: Could not add file " + file.name + ". Upload bundle size limit exceeded!";

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const myAngularErrorHandler = (<MyAngularErrorHandler>this.errorHandler);
+    myAngularErrorHandler.bugsplat.rethrowErrors = false;
     this.bugSplatEventSubscription = myAngularErrorHandler.bugsplat.getObservable()
       .subscribe((event) => {
         this.database = myAngularErrorHandler.config.database;


### PR DESCRIPTION
- Rethrow errors at the end of bugsplat.post instead of BugSplatErrorHandler
- Fixed potential memory issue where http.post wasn't being unsubscribed.
- Fixed broken tests
- Updated sample